### PR TITLE
Content undefined fix

### DIFF
--- a/components/NhsFooter.vue
+++ b/components/NhsFooter.vue
@@ -27,9 +27,10 @@
 </template>
 
 <script lang="ts">
-import { Vue } from 'nuxt-property-decorator'
+import { Vue, Component } from 'nuxt-property-decorator'
 import { ILink } from '~/interfaces'
 
+@Component
 export default class NhsFooter extends Vue {
   links: ILink[] = [
     {

--- a/components/NhsHeader.vue
+++ b/components/NhsHeader.vue
@@ -25,24 +25,6 @@
   </header>
 </template>
 
-<script lang="ts">
-import { Vue } from 'nuxt-property-decorator'
-import { ILink } from '~/interfaces'
-
-export default class NhsHeader extends Vue {
-  links: ILink[] = [
-    {
-      title: 'Accessibility statement',
-      url: 'https://thelearningcollaborative.co.uk/accessibility',
-    },
-    {
-      title: 'Respiratory Surge in Children programme',
-      url: 'https://www.e-lfh.org.uk/programmes/respiratory_surge_in_children/',
-    },
-  ]
-}
-</script>
-
 <style lang="scss">
 @import 'node_modules/nhsuk-frontend/packages/components/header/header';
 </style>

--- a/components/Resources.vue
+++ b/components/Resources.vue
@@ -102,7 +102,7 @@
               </dd>
             </div>
             <div
-              v-if="resource.lived_experience > 0"
+              v-if="resource.lived_experience"
               class="ltlc-details__duration nhsuk-body-s"
             >
               <dt>Lived Experience</dt>
@@ -112,7 +112,7 @@
               </dd>
             </div>
             <div
-              v-if="resource.easy_read > 0"
+              v-if="resource.easy_read"
               class="ltlc-details__duration nhsuk-body-s"
             >
               <dt>Easy Read</dt>
@@ -122,7 +122,7 @@
               </dd>
             </div>
             <div
-              v-if="resource.certifiable > 0"
+              v-if="resource.certifiable"
               class="ltlc-details__duration nhsuk-body-s"
             >
               <dt>Certification</dt>

--- a/components/SelectedList.vue
+++ b/components/SelectedList.vue
@@ -115,7 +115,7 @@ export default class SelectedList extends Vue {
   @Prop({ required: true }) readonly viewList!: boolean
   @Prop({ required: true }) readonly editingList!: boolean
 
-  removeItem(item) {
+  removeItem(item: IResource) {
     this.$emit('update:editing-list', true)
     const newList = this.selected.filter((i) => {
       return i !== item
@@ -123,17 +123,17 @@ export default class SelectedList extends Vue {
     this.$emit('update:selected', newList)
   }
 
-  moveUp(item) {
+  moveUp(item: IResource) {
     const i = this.selected.indexOf(item)
     this.moveItem(i, i - 1)
   }
 
-  moveDown(item) {
+  moveDown(item: IResource) {
     const i = this.selected.indexOf(item)
     this.moveItem(i, i + 1)
   }
 
-  moveItem(oldIndex, newIndex) {
+  moveItem(oldIndex: number, newIndex: number) {
     this.$emit('update:editing-list', true)
     const arr = this.selected
 

--- a/components/ShareModal.vue
+++ b/components/ShareModal.vue
@@ -55,7 +55,7 @@ export default class ShareModal extends Vue {
     this.$emit('update:share-modal', false)
   }
 
-  copyToClipboard(text) {
+  copyToClipboard(text: string) {
     const sampleTextarea = document.createElement('textarea')
     document.body.appendChild(sampleTextarea)
     sampleTextarea.value = text

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,8 +25,11 @@
           <h2>Can't find what you are looking for?</h2>
           <p>
             Please email
-            <a href="mailto:Learningnetwork@nhselect.org.uk">Learningnetwork@nhselect.org.uk</a> stating what
-            you need and we will do our best to locate some suitable resources.
+            <a href="mailto:Learningnetwork@nhselect.org.uk">
+              Learningnetwork@nhselect.org.uk
+            </a>
+            stating what you need and we will do our best to locate some
+            suitable resources.
           </p>
         </div>
         <div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "strict": true,
     "noEmit": true,
     "experimentalDecorators": true,
-    "noImplicitAny": false,
     "baseUrl": ".",
     "paths": {
       "~/*": [
@@ -28,6 +27,10 @@
       "@nuxt/types",
       "@nuxt/content",
       "@types/node",
+    ],
+    "typeRoots": [
+      "node_modules/@types",
+      "./types"
     ]
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,8 @@
     "node_modules",
     ".nuxt",
     "dist"
-  ]
+  ],
+  "vueCompilerOptions": {
+    "target": 2
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'qrcode.vue';


### PR DESCRIPTION
Missing @Component property decorator in Header and Footer components was causing nuxt-content component to fail and return "undeclared" for text items.

Also removed the false tag on noImplicitAny in tsconfig, and correctly typed some additional properties as needed.